### PR TITLE
Fix bracketing of app0

### DIFF
--- a/src/SMT/Script/Show.agda
+++ b/src/SMT/Script/Show.agda
@@ -222,6 +222,8 @@ module _ where
       return $ showName n
     showTermS (lit l) = do
       return $ showLiteral l
+    showTermS (app x []) = do
+      return $ showIdentifier x
     showTermS (app x xs) = do
       let x = showIdentifier x
       xs ← showArgsS xs


### PR DESCRIPTION
Single identifiers were being bracketed e.g. `(true)` which Z3 chokes on. I tried altering `mkSTerm` but it resulted in things like `check-sat` being incorrectly unbracketed.