### PR TITLE
Reflect context

### DIFF
--- a/src/SMT/Backend/Base.agda
+++ b/src/SMT/Backend/Base.agda
@@ -8,7 +8,7 @@
 
 module SMT.Backend.Base where
 
-open import Data.List as List using (List; _∷_; [])
+open import Data.List as List using (List; _∷_; []; foldl)
 open import Data.List.Relation.Unary.All as All using (All; _∷_; [])
 open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.String as String using (String)
@@ -87,7 +87,9 @@ module Solver {theory : Theory} (reflectable : Reflectable theory) where
   solve : String → (∀ {Γ ξ Ξ} → Script [] Γ (ξ ∷ Ξ) → Rfl.TC (Outputs (ξ ∷ Ξ))) → Rfl.Term → Rfl.TC ⊤
   solve name solver hole = do
     goal ← Rfl.inferType hole
-    Γ , scr ← reflectToScript goal
+    ctx ← Rfl.getContext
+    let goal⁺ = foldl (λ b a → Rfl.pi a (Rfl.abs "" b)) goal ctx -- prepend context to the goal
+    Γ , scr ← reflectToScript goal⁺
     let scr′ = scr ◆ `get-model ∷ []
     qm ∷ [] ← solver scr′
     case qm of λ where

--- a/test/Succeed/Test_Context_Z3_Ints.agda
+++ b/test/Succeed/Test_Context_Z3_Ints.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --allow-exec #-}
+{-# OPTIONS --guardedness #-}
+
+module Test_Context_Z3_Ints where
+
+open import Data.Integer using (ℤ; _+_)
+open import Data.Empty using (⊥)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import SMT.Theories.Ints as Ints
+open import SMT.Backend.Z3 Ints.reflectable
+
+import Data.Integer.Literals as Int using (number; negative)
+
+instance _ = Int.number
+         _ = Int.negative
+
+t₁ : (x y : ℤ) → x + y ≡ y + x
+t₁ x y = solveZ3
+
+t₂ : (x y z w : ℤ) → x ≡ y → z ≡ w → x + z ≡ y + w
+t₂ x y z w x≡y z≡w = solveZ3
+
+postulate
+  t₃ : (x y : ℤ) → x ≡ y
+
+-- We can add arbitrary lemmas to the context to help the solver.
+t₄ : (x y : ℤ) → y ≡ x
+t₄ x y with t₃ x y
+...       | _ = solveZ3
+
+-- The above example doesn't work with let, it seems like bindings
+-- introduced by let is not added to the context.
+-- t₅ : (x y : ℤ) → y ≡ x
+-- t₅ x y = let _ = t₃ x y
+--           in solveZ3


### PR DESCRIPTION
Reflecting context to SMT script by prepending it to the goal as Pi types, it also allows adding arbitrary lemmas to the context to help the solver (see examples in test/Succeed/Test_Context_Z3_Ints.agda). 

One thing I'm not sure is that I'm generating SMT script  using `goal⁺` but building the proof using `goal`, which works fine right now because we're not generating any interesting proofs, maybe later we need to tweak `buildProof` to also take context into account?