### PR TITLE
Upgrade to agda-stdlib/experimental

### DIFF
--- a/src/Reflection/Normalise.agda
+++ b/src/Reflection/Normalise.agda
@@ -12,11 +12,11 @@ open import Data.Unit
 open import Function
 
 open import Reflection
-open import Reflection.TypeChecking.Monad.Categorical using (applicative)
+open import Reflection.TCM.Effectful using (applicative)
 
-open import Reflection.Universe
-open import Reflection.Annotated
-open import Reflection.Annotated.Free
+open import Reflection.AST.Universe
+open import Reflection.AnnotatedAST
+open import Reflection.AnnotatedAST.Free
 
 private
   Ann : ∀ {k} → ⟦ k ⟧ → Set

--- a/src/SMT/Backend/Base.agda
+++ b/src/SMT/Backend/Base.agda
@@ -10,7 +10,7 @@ module SMT.Backend.Base where
 
 open import Data.List as List using (List; _∷_; []; foldl)
 open import Data.List.Relation.Unary.All as All using (All; _∷_; [])
-open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Data.String as String using (String)
 open import Data.Unit using (⊤)
 open import Function using (case_of_; const; _$_; _∘_; flip)
@@ -104,7 +104,7 @@ module Solver (theory : Theory) {{reflectable : Reflectable theory}} where
   solve name solver hole = do
     goal ← Rfl.inferType hole
     ctx ← Rfl.getContext
-    let goal⁺ = foldl (λ b a → Rfl.pi a (Rfl.abs "" b)) goal ctx -- prepend context to the goal
+    let goal⁺ = foldl (λ b (x , a) → Rfl.pi a (Rfl.abs x b)) goal ctx -- prepend context to the goal
     Γ , scr ← reflectToScript goal⁺
     let scr′ = scr ◆ `get-model []
     qm ∷ [] ← solver scr′

--- a/src/SMT/Script/Names.agda
+++ b/src/SMT/Script/Names.agda
@@ -13,8 +13,8 @@ module SMT.Script.Names (theory : Theory) where
 
 open Theory theory
 
-open import Category.Monad
-open import Category.Monad.State as StateCat using (RawIMonadState; IStateT)
+open import Effect.Monad
+open import Effect.Monad.State as StateCat using (RawIMonadState; IStateT)
 open import Codata.Musical.Stream as Stream using (Stream)
 open import Data.Char as Char using (Char)
 open import Data.Environment as Env using (Env; _∷_; [])
@@ -30,7 +30,7 @@ open import Data.String as String using (String)
 open import Data.Unit as Unit using (⊤)
 open import Data.Vec as Vec using (Vec)
 open import Function using (const; id; _∘_; _$_)
-import Function.Identity.Categorical as Identity
+import Function.Identity.Effectful as Identity
 open import Text.Parser.String as P hiding (_>>=_)
 open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Nullary.Decidable using (True)

--- a/src/SMT/Script/Reflection.agda
+++ b/src/SMT/Script/Reflection.agda
@@ -14,21 +14,21 @@ module SMT.Script.Reflection (theory : Theory) {{reflectable : Reflectable theor
 open Theory theory
 open Reflectable reflectable
 
-open import Category.Monad
+open import Effect.Monad
 open import Data.Environment as Env using (Env; _∷_; [])
 open import Data.Fin as Fin using (Fin; suc; zero)
 open import Data.List as List using (List; _∷_; []; _++_; length)
 open import Data.List.Relation.Unary.All using (All; _∷_; [])
 open import Data.List.Relation.Unary.Any as Any using (here; there)
 open import Data.Maybe as Maybe using (Maybe; just; nothing)
-import Data.Maybe.Categorical as MaybeCat
+import Data.Maybe.Effectful as MaybeCat
 open import Data.Nat as Nat using (ℕ; suc; zero)
 open import Data.Product as Prod using (∃; ∃-syntax; -,_; _×_; _,_; proj₁; proj₂)
 open import Data.String as String using (String)
 open import Data.Unit as Unit using (⊤)
 open import Data.Vec as Vec using (Vec; _∷_; [])
 open import Function using (_$_; case_of_; _∘_; const; flip; id)
-import Function.Identity.Categorical as Identity
+import Function.Identity.Effectful as Identity
 import Level
 import Reflection as Rfl
 open import Relation.Nullary using (Dec; yes; no)
@@ -146,10 +146,10 @@ module _ where
 module _ where
 
   open import SMT.Theory.Raw.Reflection
-  import Reflection.TypeChecking.Monad.Categorical as TC
+  import Reflection.TCM.Effectful as TC
 
   private
-    open module TCMonad {ℓ} = Category.Monad.RawMonad {ℓ} TC.monad renaming (_⊛_ to _<*>_)
+    open module TCMonad {ℓ} = Effect.Monad.RawMonad {ℓ} TC.monad renaming (_⊛_ to _<*>_)
 
   reflectToScript : Rfl.Term → Rfl.TC (∃[ Γ ] Script [] Γ [])
   reflectToScript t = do

--- a/src/SMT/Script/Show.agda
+++ b/src/SMT/Script/Show.agda
@@ -18,7 +18,7 @@ open Theory theory
 open Parsable parsable
 open Printable printable
 
-open import Category.Monad
+open import Effect.Monad
 open import Codata.Musical.Stream as Stream using (Stream)
 open import Data.Char as Char using (Char)
 open import Data.Environment as Env using (Env; _∷_; [])
@@ -29,7 +29,7 @@ open import Data.List.Relation.Unary.Any as Any using (here; there)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_)
 open import Data.Maybe as Maybe using (Maybe; just; nothing)
-import Data.Maybe.Categorical as MaybeCat
+import Data.Maybe.Effectful as MaybeCat
 open import Data.Nat as Nat using (ℕ; suc; zero)
 open import Data.Nat.Show renaming (show to showℕ)
 open import Data.Product as Prod using (∃; ∃-syntax; -,_; _×_; _,_; proj₁; proj₂)
@@ -37,7 +37,7 @@ open import Data.String as String using (String)
 open import Data.Unit as Unit using (⊤)
 open import Data.Vec as Vec using (Vec; _∷_; [])
 open import Function using (_$_; case_of_; _∘_; const; flip; id)
-import Function.Identity.Categorical as Identity
+import Function.Identity.Effectful as Identity
 import Level
 import Reflection as Rfl
 open import Relation.Nullary using (yes; no)
@@ -200,7 +200,7 @@ module _ where
 
 module _ where
 
-  open import Category.Monad.State as StateCat using (RawIMonadState; IStateT)
+  open import Effect.Monad.State as StateCat using (RawIMonadState; IStateT)
   open import Text.Parser.String using (IUniversal; Parser; _<$_; withSpaces; exacts)
 
   NameState : (Γ Γ′ : Ctxt) → Set → Set

--- a/src/SMT/Theories/Ints/Base.agda
+++ b/src/SMT/Theories/Ints/Base.agda
@@ -15,7 +15,7 @@ open import Data.Nat.Base as Nat using (ℕ)
 open import Data.Nat.Show renaming (show to showℕ)
 open import Data.List as List using (List; _∷_; [])
 open import Data.String as String using (String)
-open import Function.Equivalence using (equivalence)
+open import Function using (mk⇔)
 import Reflection as Rfl
 open import Relation.Nullary using (Dec; yes; no)
 import Relation.Nullary.Decidable as Dec
@@ -52,7 +52,7 @@ CORE-injective : CORE φ ≡ CORE φ′ → φ ≡ φ′
 CORE-injective refl = refl
 
 _≟-Sort_ : (σ σ′ : Sort) → Dec (σ ≡ σ′)
-CORE φ ≟-Sort CORE φ′ = Dec.map (equivalence (PropEq.cong CORE) CORE-injective) (φ ≟-CoreSort φ′)
+CORE φ ≟-Sort CORE φ′ = Dec.map (mk⇔ (PropEq.cong CORE) CORE-injective) (φ ≟-CoreSort φ′)
 CORE φ ≟-Sort INT     = no (λ ())
 INT    ≟-Sort CORE φ  = no (λ ())
 INT    ≟-Sort INT     = yes refl

--- a/src/SMT/Theories/Nats/Solvable.agda
+++ b/src/SMT/Theories/Nats/Solvable.agda
@@ -116,8 +116,8 @@ translation = record
 
     module _ where
       open import Level
-      open import Data.Sum.Categorical.Left InterpError Level.zero using (monad)
-      open import Category.Monad
+      open import Data.Sum.Effectful.Left InterpError Level.zero using (monad)
+      open import Effect.Monad
 
       open RawMonad monad
 

--- a/src/SMT/Theory/Class/Parsable.agda
+++ b/src/SMT/Theory/Class/Parsable.agda
@@ -5,6 +5,7 @@
 -- and values output as part of the SMT-LIB model.
 --------------------------------------------------------------------------------
 
+{-# OPTIONS --guardedness #-}
 module SMT.Theory.Class.Parsable where
 
 open import SMT.Theory.Base

--- a/src/SMT/Theory/Raw/Base.agda
+++ b/src/SMT/Theory/Raw/Base.agda
@@ -23,9 +23,8 @@ open import Data.List as List using (List; []; _∷_)
 open import Data.Product as Prod using (_×_; _,_; proj₁; proj₂)
 open import Data.String as String using (String)
 open import Function using (id)
-open import Function.Equivalence using (equivalence)
 import Reflection as Rfl
-open import Reflection.Term using () renaming (_≟_ to _≟-Term_)
+open import Reflection.AST.Term using () renaming (_≟_ to _≟-Term_)
 open import Relation.Nullary using (Dec; yes; no)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
@@ -46,7 +45,7 @@ _≟-RawSort_ : (σ σ′ : RawSort) → Dec (σ ≡ σ′)
 ⋆      ≟-RawSort ⋆       = yes refl
 ⋆      ≟-RawSort TERM _  = no λ()
 TERM x ≟-RawSort ⋆       = no λ()
-TERM t ≟-RawSort TERM t′ = Dec.map (equivalence (cong TERM) TERM-injective) (t ≟-Term t′)
+TERM t ≟-RawSort TERM t′ = Dec.map (Function.mk⇔ (cong TERM) TERM-injective) (t ≟-Term t′)
 
 rawTheory : Theory
 Theory.Sort        rawTheory = RawSort

--- a/src/SMT/Utils/Float.agda
+++ b/src/SMT/Utils/Float.agda
@@ -1,13 +1,13 @@
 module SMT.Utils.Float where
 
-open import Category.Monad
+open import Effect.Monad
 open import Data.Bool as Bool using (Bool; false; true; T; not; _∧_; if_then_else_)
 open import Data.Char as Char using (Char)
 open import Data.Float as Float using (Float; isNaN; _≤ᵇ_; _<ᵇ_)
 open import Data.Integer as Int using (ℤ; _◃_; +_; -[1+_])
 open import Data.List as List using (List; []; _∷_; _∷ʳ′_; initLast; _∷ʳ_; _++_; splitAt; replicate)
 open import Data.Maybe as Maybe using (Maybe; nothing; just)
-import Data.Maybe.Categorical as MaybeCat
+import Data.Maybe.Effectful as MaybeCat
 open import Data.Nat as Nat using (ℕ; suc; zero; _*_; _+_; _∸_)
 open import Data.Product as Prod using (_×_; _,_)
 import Data.Sign as Sign

--- a/src/Text/Parser/String.agda
+++ b/src/Text/Parser/String.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --guardedness #-}
 module Text.Parser.String where
 
 open import Data.Bool.Base using (T; not)


### PR DESCRIPTION
I wanted to try schmitty and figured it would be faster to do the patch than to recompile Agda.

And the extra `--guardedness` is for compatibility with agdarsec master.